### PR TITLE
refactor: 입력 및 라디오 폼 컴포넌트 확장성 개선

### DIFF
--- a/src/components/FormInputGroup.tsx
+++ b/src/components/FormInputGroup.tsx
@@ -6,22 +6,17 @@ import { FormErrorMessage } from "@/components/FormErrorMessage";
 import { getFieldPlaceholder } from "@/shared/utils/form-placeholder";
 import { twMerge as tw } from "tailwind-merge";
 
-const formatDisplayLabel = (category: string, label: string): string => {
-  if (!category.includes("Cam")) return label;
+interface FormInputGroupProps {
+  field: FormField;
+  formatLabel?: (category: string, label: string) => string;
+}
 
-  let position = "";
-  if (label.includes("Left")) position = "Left";
-  else if (label.includes("Center")) position = "Center";
-  else if (label.includes("Right")) position = "Right";
+const defaultLabelFormatter = (_category: string, label: string): string => label;
 
-  let axis = "";
-  if (label.includes("X")) axis = "X";
-  else if (label.includes("Y")) axis = "Y";
-
-  return `${position} ${axis}`;
-};
-
-export const FormInputGroup = ({ field }: { field: FormField }) => {
+export const FormInputGroup = ({
+  field,
+  formatLabel = defaultLabelFormatter,
+}: FormInputGroupProps) => {
   const {
     register,
     formState: { errors },
@@ -30,7 +25,7 @@ export const FormInputGroup = ({ field }: { field: FormField }) => {
   const { category, name, label, type } = field;
 
   const errorMessage = getFieldErrorMessage(errors, name);
-  const displayLabel = formatDisplayLabel(category, label);
+  const displayLabel = formatLabel(category, label);
   const placeholder = getFieldPlaceholder(category, name);
   const hasError = hasFieldError(errors, name);
 

--- a/src/components/FormRadioGroup.tsx
+++ b/src/components/FormRadioGroup.tsx
@@ -1,23 +1,27 @@
 import { useFormContext } from "react-hook-form";
 import { FormSchema } from "@/schemas/form-schema";
-import { FormField } from "@/types/form";
-import { SHIP_OPTIONS, ENGINE_OPTIONS } from "@/constants/form-options";
+import { FormField, FormOption } from "@/types/form";
 import { FormErrorMessage } from "@/components/FormErrorMessage";
 import { getFieldErrorMessage, hasFieldError } from "@/shared/utils/form-error";
 import { twMerge as tw } from "tailwind-merge";
 
-export const FormRadioGroup = ({ field }: { field: FormField }) => {
+interface FormRadioGroupProps {
+  field: FormField;
+  options?: FormOption<string>[];
+}
+
+export const FormRadioGroup = ({ field, options }: FormRadioGroupProps) => {
   const {
     register,
     formState: { errors },
   } = useFormContext<FormSchema>();
   const { name, label } = field;
 
-  const options = name === "ship_type" ? SHIP_OPTIONS : ENGINE_OPTIONS;
+  const radioOptions = options || [];
   const errorMessage = getFieldErrorMessage(errors, name);
   const hasError = hasFieldError(errors, name);
 
-  const isHorizontalLayout = options.length <= 2;
+  const isHorizontalLayout = radioOptions.length <= 2;
 
   return (
     <div className="space-y-4">
@@ -25,7 +29,7 @@ export const FormRadioGroup = ({ field }: { field: FormField }) => {
         {label}
       </div>
       <div className={isHorizontalLayout ? "flex space-x-6" : "space-y-4"}>
-        {options.map((option) => (
+        {radioOptions.map((option) => (
           <div key={option.value} className="flex items-center">
             <div className="relative flex items-center">
               <input

--- a/src/components/FormSection.tsx
+++ b/src/components/FormSection.tsx
@@ -8,9 +8,24 @@ interface FormSectionProps {
   fields: FormField[];
 }
 
-const RADIO_OPTIONS: Record<string, FormOption<string>[]> = {
+const DEFAULT_OPTIONS: Record<string, FormOption<string>[]> = {
   ship_type: SHIP_OPTIONS,
   engine: ENGINE_OPTIONS,
+};
+
+const cameraLabelFormatter = (category: string, label: string): string => {
+  if (!category.includes("Cam")) return label;
+
+  let position = "";
+  if (label.includes("Left")) position = "Left";
+  else if (label.includes("Center")) position = "Center";
+  else if (label.includes("Right")) position = "Right";
+
+  let axis = "";
+  if (label.includes("X")) axis = "X";
+  else if (label.includes("Y")) axis = "Y";
+
+  return `${position} ${axis}`;
 };
 
 export const FormSection = ({ title, fields }: FormSectionProps) => {
@@ -20,9 +35,9 @@ export const FormSection = ({ title, fields }: FormSectionProps) => {
       <div className="grid gap-4">
         {fields.map((field) =>
           field.type === "radio" ? (
-            <FormRadioGroup key={field.name} field={field} options={RADIO_OPTIONS[field.name]} />
+            <FormRadioGroup key={field.name} field={field} options={DEFAULT_OPTIONS[field.name]} />
           ) : (
-            <FormInputGroup key={field.name} field={field} />
+            <FormInputGroup key={field.name} field={field} formatLabel={cameraLabelFormatter} />
           )
         )}
       </div>

--- a/src/components/FormSection.tsx
+++ b/src/components/FormSection.tsx
@@ -1,11 +1,17 @@
-import { FormField } from "@/types/form";
+import { FormField, FormOption } from "@/types/form";
 import { FormRadioGroup } from "./FormRadioGroup";
 import { FormInputGroup } from "./FormInputGroup";
+import { SHIP_OPTIONS, ENGINE_OPTIONS } from "@/constants/form-options";
 
 interface FormSectionProps {
   title: string;
   fields: FormField[];
 }
+
+const RADIO_OPTIONS: Record<string, FormOption<string>[]> = {
+  ship_type: SHIP_OPTIONS,
+  engine: ENGINE_OPTIONS,
+};
 
 export const FormSection = ({ title, fields }: FormSectionProps) => {
   return (
@@ -14,7 +20,7 @@ export const FormSection = ({ title, fields }: FormSectionProps) => {
       <div className="grid gap-4">
         {fields.map((field) =>
           field.type === "radio" ? (
-            <FormRadioGroup key={field.name} field={field} />
+            <FormRadioGroup key={field.name} field={field} options={RADIO_OPTIONS[field.name]} />
           ) : (
             <FormInputGroup key={field.name} field={field} />
           )


### PR DESCRIPTION
## 관련 이슈

> closes #30 


## 작업 내용
입력 및 라디오 폼 컴포넌트 확장성 개선



### 수정 파일
- 입력 폼 컴포넌트: `src/components/FormInputGroup.tsx`
- 라디오 폼 컴포넌트: `src/components/FormRadioGroup.tsx`
- 폼 섹션 컴포넌트: `src/components/FormSection.tsx`

### 상세 내용
1. `src/components/FormInputGroup.tsx`
   - `formatLabel` prop 추가하여 레이블 포맷팅 옵션 제공
   - 레이블 포맷팅 로직을 컴포넌트 외부에서 주입 가능하도록 개선

2. `src/components/FormRadioGroup.tsx`
   - `options` prop 추가하여 외부에서 옵션 주입 가능하도록 개선
   - 하드코딩된 조건부 로직 제거로 컴포넌트 범용성 향상

3. `src/components/FormSection.tsx`
   - 기본 옵션 관리 및 필드별 옵션 전달 구조 개선
   - 필드 타입에 따른 컴포넌트 렌더링 로직 개선
   - FormInputGroup과 FormRadioGroup에 필요한 props 전달 구조 개선

### 구현 효과
FormInputGroup과 FormRadioGroup을 범용적으로 재사용 가능하게 만들고, FormSection에서 setting-page 특화 요구사항만 처리하는 명확한 관심사 분리 구조로 개선

### 추후 작업 내용
관심사에 따라 공통 컴포넌트는 common 폴더로, 페이지별 컴포넌트는 각 페이지명 폴더로 이동하여 코드 구조 개선 예정
