### PR TITLE
refactor: UI 문자열 중앙화

### DIFF
--- a/src/app/layout/template.tsx
+++ b/src/app/layout/template.tsx
@@ -1,12 +1,13 @@
 import { Outlet } from "react-router";
-import { ThemeToggle } from "@/components/ThemeToggle";
+import { ThemeToggle } from "@/components/common/ThemeToggle";
+import { UI_STRINGS } from "@/constants/ui-string";
 
 export const Template = () => {
   return (
     <div className="flex min-h-full flex-col">
       <div className="bg-background/60 sticky top-0 right-0 left-0 border-b-1 border-dashed px-10 backdrop-blur-xs">
         <div className="flex justify-between border-x-1 border-dashed px-8 py-4">
-          <span className="text-foreground text-xl font-bold">HiNAS Camera</span>
+          <span className="text-foreground text-xl font-bold">{UI_STRINGS.BRAND_NAME}</span>
           <ThemeToggle />
         </div>
       </div>

--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -1,3 +1,4 @@
+import { UI_STRINGS } from "@/constants/ui-string";
 import { useState, useLayoutEffect } from "react";
 
 export const ThemeToggle = () => {
@@ -38,7 +39,7 @@ export const ThemeToggle = () => {
         />
       </div>
       <span className="ml-2 hidden text-sm font-medium sm:inline">
-        {isDarkMode ? "dark" : "light"}
+        {isDarkMode ? UI_STRINGS.THEME_DARK : UI_STRINGS.THEME_LIGHT}
       </span>
     </button>
   );

--- a/src/components/setting-page/ParameterViewModal.tsx
+++ b/src/components/setting-page/ParameterViewModal.tsx
@@ -2,6 +2,7 @@ import { CustomModal } from "@/components/common/CustomModal";
 import { FormSchema } from "@/schemas/form-schema";
 import { getJsonString } from "@/shared/lib/get-json-string";
 import { CustomButton } from "@/components/common/CustomButton";
+import { UI_STRINGS } from "@/constants/ui-string";
 
 interface ParameterViewModalProps {
   isOpen: boolean;
@@ -20,7 +21,7 @@ export const ParameterViewModal = ({ isOpen, onClose, data }: ParameterViewModal
         {formattedData}
       </pre>
       <div className="flex justify-end">
-        <CustomButton buttonText="Close" className="w-auto" onClick={onClose} type="button" />
+        <CustomButton buttonText={UI_STRINGS.BUTTON_CLOSE} className="w-auto" onClick={onClose} type="button" />
       </div>
     </CustomModal>
   );

--- a/src/constants/ui-string.ts
+++ b/src/constants/ui-string.ts
@@ -1,0 +1,8 @@
+export const UI_STRINGS = {
+  BRAND_NAME: "HiNAS Camera",
+  TITLE: "Camera Parameter",
+  BUTTON_SUBMIT: "Submit",
+  BUTTON_CLOSE: "Close",
+  THEME_DARK: "Dark",
+  THEME_LIGHT: "Light",
+};

--- a/src/pages/setting-page.tsx
+++ b/src/pages/setting-page.tsx
@@ -7,6 +7,7 @@ import { SettingFormSection } from "@/components/setting-page/SettingFormSection
 import { groupFieldsByCategory, sortFieldsByOrder } from "@/shared/utils/form-fields-utils";
 import { CustomButton } from "@/components/common/CustomButton";
 import { ParameterViewModal } from "@/components/setting-page/ParameterViewModal";
+import { UI_STRINGS } from "@/constants/ui-string";
 
 const CATEGORY_SORT_CONFIG: Record<string, string[]> = {
   "Roll Pitch Yaw": ["Roll", "Pitch", "Yaw"],
@@ -42,14 +43,14 @@ export const SettingPage = () => {
 
   return (
     <div className="mx-auto max-w-xl p-6">
-      <h2 className="mb-12 text-3xl font-bold">Camera Parameter</h2>
+      <h2 className="mb-12 text-3xl font-bold">{UI_STRINGS.TITLE}</h2>
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)} className="space-y-12">
           {Object.entries(organizedFields).map(([category, fields]) => (
             <SettingFormSection key={category} title={category} fields={fields} />
           ))}
 
-          <CustomButton buttonText="Submit" className="mt-4 flex w-full justify-center" />
+          <CustomButton buttonText={UI_STRINGS.BUTTON_SUBMIT} className="mt-4 flex w-full justify-center" />
         </form>
       </FormProvider>
 


### PR DESCRIPTION
## 관련 이슈

> closes #34


## 작업 내용
UI 문자열 중앙화


### 추가 파일
- UI 문자열 상수: `src/constants/ui-string.ts`

### 수정 파일
- 테마 토글 컴포넌트: `src/components/common/ThemeToggle.tsx`
- 파라미터 뷰 모달: `src/components/setting-page/ParameterViewModal.tsx`
- 레이아웃 템플릿: `src/app/layout/template.tsx`
- 설정 페이지: `src/pages/setting-page.tsx`

### 상세 내용
1. `src/constants/ui-string.ts` 파일 생성
   - 애플리케이션에서 사용되는 UI 문자열을 중앙 관리하는 상수 파일 추가
   - 기본 UI 문자열(제목, 버튼 텍스트, 테마 이름 등) 정의

2. 기존 컴포넌트에 UI 문자열 상수 적용
   - 하드코딩된 텍스트를 상수로 대체
   - 타이틀, 버튼 텍스트, 테마 관련 문자열 등에 적용

### 구현 효과
하드코딩된 문자열을 중앙 관리되는 상수로 대체하여 일관성 향상



